### PR TITLE
cmake: require 3.10 as the minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 #    misrepresented as being the original software.
 # 3. This notice may not be removed or altered from any source distribution.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 project(tinycmmc VERSION 0.1.0)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
With cmake 4 it now errors unless the minimum version is at least 3.5 and it will warn if the version is not at least 3.10.

Gentoo-Issue: https://bugs.gentoo.org/952072