### PR TITLE
build: set the cmake_minimum_required as a range

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 #    misrepresented as being the original software.
 # 3. This notice may not be removed or altered from any source distribution.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...4.1)
 project(tinycmmc VERSION 0.1.0)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
From the cmake documentation:
```
  This uses the <min>...<max> syntax to enable the NEW behaviors of
  policies introduced in CMake 4.1 and earlier while only requiring
  a minimum version of CMake 3.10.
```
Resource: https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html#updating-projects

Also see: https://github.com/Grumbel/sdl-jstest/pull/28